### PR TITLE
Af/chore/add dns lookup family v4only config

### DIFF
--- a/.github/workflows/gcloud-run.yml
+++ b/.github/workflows/gcloud-run.yml
@@ -1,4 +1,4 @@
-name: Deploy CGP
+name: Deploy GCP
 
 on:
   workflow_call:

--- a/.github/workflows/gcloud-run.yml
+++ b/.github/workflows/gcloud-run.yml
@@ -144,6 +144,7 @@ jobs:
           --vpc-egress all-traffic \
           --service-account "$SERVICE_ACCOUNT" \
           --min-instances 1 \
+          --backend_dns_lookup_family v4only \
 
   deploy-grpc:
     name: Deploy Gcloud GRPC
@@ -173,3 +174,4 @@ jobs:
           --vpc-egress all-traffic \
           --service-account "$SERVICE_ACCOUNT" \
           --min-instances 1 \
+          --backend_dns_lookup_family v4only \


### PR DESCRIPTION
A tiba está implementando um sistema de monitoramento de serviços com o Datadog.  Esta ferramenta faz o trace de requisições e gerenciamento de logs das chamadas. 
Cada requisição feita em um container do **Cloud Run** acompanha todas as chamadas internas. Ou seja, através do datadog conseguimos acompanhar se a requisição necessitou de um serviço externo (chamada serviço **grpc, starkbank, google-logging,** etc.).

⚠️ **O Problema:** As chamadas entre serviços englobados no **GCP** estão sendo feitos, preferencialmente, por IPv6. O IPv6 não é alcançado, gerando o seguinte erro: 
```
Error: connect EHOSTUNREACH [IPv6]:443 - Local (:::0)
    at internalConnect (node:net:1041:16)
    at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
    at node:net:1134:9
    at processTicksAndRejections (node:internal/process/task_queues:78:11)
```

Após o servidor não ser alcançado através do IPv6, um fallback para o IPv4 é acionado e a comunicação acontece.
De acordo com a [issue#423](https://github.com/GoogleCloudPlatform/esp-v2/issues/423) do GoogleCloudPlatform/esp-v2 adicionar a flag —backend_dns_lookup_family=v4only faz com que as chamadas sejam feitas diretamente ao endereço IPv4 do domínio.

Nota-se que, de acordo com a [documentação do ESPv2](https://cloud.google.com/endpoints/docs/openapi/specify-esp-v2-startup-options?hl=pt-br), esta flag pode se fazer necessária caso a implantação seja feita fora do ambiente gcloud. Que, foi observado que é nosso caso, já que o gerenciamento dos containers é feito pela Knative.